### PR TITLE
Fix password parameter

### DIFF
--- a/lib/handle_acsm.py
+++ b/lib/handle_acsm.py
@@ -26,9 +26,9 @@ def handle_acsm(acsm_path):
             [
                 'adept_activate',
                 '-u', email,
-                '-O', str(adobe_dir)
+                '-O', str(adobe_dir),
+                '-p', str(password)
             ],
-            stdin=password+'\n',
             cleanser=lambda:shutil.rmtree(str(adobe_dir))
         )
 

--- a/lib/handle_acsm.py
+++ b/lib/handle_acsm.py
@@ -29,7 +29,8 @@ def handle_acsm(acsm_path):
                 '-O', str(adobe_dir),
                 '-p', str(password)
             ],
-            cleanser=lambda:shutil.rmtree(str(adobe_dir))
+            cleanser=lambda:shutil.rmtree(str(adobe_dir)),
+            verbose=False
         )
 
     click.echo('Downloading the book from Adobe...')

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -2,15 +2,14 @@ import click, subprocess, sys
 
 # run a command and display output in a styled terminal
 # cleanser is called if the command returns a >0 exit code
-def run(command: [str], cleanser = lambda: None) -> int:
-
-    open_fake_terminal(' '.join(command))
+def run(command: [str], cleanser = lambda: None, verbose=True) -> int:
+    if verbose:
+        open_fake_terminal(' '.join(command))
     result = subprocess.run(
         command,
         stderr=subprocess.STDOUT,
         check=False # don't throw Python error if returncode isn't 0
     )
-
     close_fake_terminal(result.returncode, cleanser)
 
     return result.returncode

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -2,14 +2,12 @@ import click, subprocess, sys
 
 # run a command and display output in a styled terminal
 # cleanser is called if the command returns a >0 exit code
-def run(command: [str], stdin: str = '', cleanser = lambda: None) -> int:
+def run(command: [str], cleanser = lambda: None) -> int:
 
     open_fake_terminal(' '.join(command))
-
     result = subprocess.run(
         command,
         stderr=subprocess.STDOUT,
-        input=stdin.encode(),
         check=False # don't throw Python error if returncode isn't 0
     )
 


### PR DESCRIPTION
### Context:
passing the adobe password via stdin is dropping special characters, adding it directly to the command args works as expected.  
#### Addresses issue:
 [Issues with special characters in passwords #38](https://github.com/BentonEdmondson/knock/issues/38
)
### Changes:
Removed stdin parameter
password passed as command arg
Added verbose param to run() to prevent outputting the password to console.