### PR TITLE
Multi system

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,21 @@
         "url": "https://gist.github.com/f0fd86b6c73063283afe550bc5d77594.git"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gourou-src": {
       "flake": false,
       "locked": {
@@ -34,16 +49,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654230545,
-        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
+        "lastModified": 1656006128,
+        "narHash": "sha256-CnKiuYAZ2GhTODua740NR5i4zSjtgPbDidZR1/hBynY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "236cc2971ac72acd90f0ae3a797f9f83098b17ec",
+        "rev": "3d54f15c00a96578befbcfb4b32094f2a38cfbdb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -68,6 +82,7 @@
     "root": {
       "inputs": {
         "base64-src": "base64-src",
+        "flake-utils": "flake-utils",
         "gourou-src": "gourou-src",
         "nixpkgs": "nixpkgs",
         "pugixml-src": "pugixml-src",

--- a/flake.nix
+++ b/flake.nix
@@ -98,8 +98,8 @@
           name = "gourou";
           src = "${gourou-src}";
 
-          patchPhase = ''
-            rm -f src/pugixml.cpp
+          postPatch = "rm -f src/pugixml.cpp";
+          patchPhase = optionalString (stdenv.isDarwin) ''
             rm -f src/device.cpp
             cp ${packages.knock.src}/patches/gourou/device.cpp src/device.cpp
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -149,7 +149,7 @@
 
           buildPhase = ''
             ${cc} \
-              -o $name \
+              -o knock \
               src/knock.cpp \
               -D KNOCK_VERSION='"${version}"' \
               --std=c++17 \
@@ -171,9 +171,9 @@
               -lcrypto \
               -lcurl \
               -lssl \
-              ${packages.utils-common}/lib/libutils-common.a \
-              ${packages.gourou}/lib/libgourou.a \
-              ${packages.updfparser}/lib/libupdfparser.a \
+              ${packages.utils-common}/lib/lib${packages.utils-common.name}.a \
+              ${packages.gourou}/lib/lib${packages.gourou.name}.a \
+              ${packages.updfparser}/lib/lib${packages.updfparser.name}.a \
               -L${packages.libzip-static}/lib \
               -L${nixpkgs-stat.libnghttp2}/lib \
               -L${nixpkgs-stat.libidn2.out}/lib \

--- a/flake.nix
+++ b/flake.nix
@@ -99,9 +99,11 @@
           src = "${gourou-src}";
 
           postPatch = "rm -f src/pugixml.cpp";
+
           patchPhase = optionalString (stdenv.isDarwin) ''
             rm -f src/device.cpp
             cp ${packages.knock.src}/patches/gourou/device.cpp src/device.cpp
+            runHook postPatch
           '';
 
           buildPhase = ''

--- a/patches/gourou/device.cpp
+++ b/patches/gourou/device.cpp
@@ -1,0 +1,339 @@
+/*
+  Copyright 2021 Grégory Soutadé
+
+  This file is part of libgourou.
+
+  libgourou is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  libgourou is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with libgourou. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <pwd.h>
+#include <locale.h>
+
+#include <libgourou.h>
+#include <libgourou_common.h>
+#include <libgourou_log.h>
+#include <device.h>
+
+// From https://stackoverflow.com/questions/1779715/how-to-get-mac-address-of-your-machine-using-a-c-program/35242525
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <string.h>
+
+#include <net/if_dl.h>
+#include <ifaddrs.h>
+#ifdef __APPLE__
+#  define HAVE_SA_LEN
+#endif
+
+int get_mac_address(unsigned char* mac_address)
+{
+  struct ifreq ifr;
+  struct ifconf ifc;
+  char buf[1024];
+  int success = 0;
+#ifdef AF_LINK
+  struct sockaddr_dl *sdlp;
+#endif
+
+  int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+  if (sock == -1) { EXCEPTION(gourou::DEV_MAC_ERROR, "Unable to create socket"); };
+
+  ifc.ifc_len = sizeof(buf);
+  ifc.ifc_buf = buf;
+  if (ioctl(sock, SIOCGIFCONF, &ifc) == -1) { EXCEPTION(gourou::DEV_MAC_ERROR, "SIOCGIFCONF ioctl failed"); }
+
+  struct ifreq* it;
+  int n = ifc.ifc_len;
+
+#ifdef HAVE_SA_LEN
+#ifndef max
+#define max(a,b) ((a) > (b) ? (a) : (b))
+#endif
+#define ifreq_size(i) max(sizeof(struct ifreq),                     \
+                          sizeof((i).ifr_name)+(i).ifr_addr.sa_len)
+#else
+#define ifreq_size(i) sizeof(struct ifreq)
+#endif /* HAVE_SA_LEN*/
+
+  for (int i = 0; i < n; i+= ifreq_size(*it)) {
+    it = (struct ifreq *)((char *) ifc.ifc_buf+i);
+    strcpy(ifr.ifr_name, it->ifr_name);
+    if (ioctl(sock, SIOCGIFFLAGS, &ifr) == 0) {
+      if (! (ifr.ifr_flags & IFF_LOOPBACK)) { // don't count loopback
+#if defined(HAVE_SIOCGIFHWADDR)
+        if (ioctl(sock, SIOCGIFHWADDR, &ifr) == 0) {
+#elif defined(AF_LINK)
+          sdlp = (struct sockaddr_dl *) &it->ifr_addr;
+          if ((sdlp->sdl_family == AF_LINK) && (sdlp->sdl_alen == 6)) {
+#else
+            {return 1;
+#endif
+          success = 1;
+          break;
+        }
+      }
+    }
+    else { EXCEPTION(gourou::DEV_MAC_ERROR, "SIOCGIFFLAGS ioctl failed"); }
+  }
+
+  if (success)
+    {
+#ifdef SIOCGIFHWADDR
+#  define HWADDR ifr.ifr_hwaddr.sa_data
+#elif defined AF_LINK
+#  define HWADDR (unsigned char *) &sdlp->sdl_data[sdlp->sdl_nlen]
+#else
+      return 1;
+#endif
+      memcpy(mac_address, HWADDR, 6);
+      return 0;
+    }
+
+  return 1;
+}
+
+
+namespace gourou
+{
+  Device::Device(DRMProcessor* processor):
+    processor(processor)
+  {}
+
+  Device::Device(DRMProcessor* processor, const std::string& deviceFile, const std::string& deviceKeyFile):
+    processor(processor), deviceFile(deviceFile), deviceKeyFile(deviceKeyFile)
+  {
+    parseDeviceKeyFile();
+    parseDeviceFile();
+  }
+
+  /* SHA1(uid ":" username ":" macaddress ":" */
+  std::string Device::makeSerial(bool random)
+  {
+    unsigned char sha_out[SHA1_LEN];
+    DRMProcessorClient* client = processor->getClient();
+
+    if (!random)
+      {
+        uid_t uid = getuid();
+        struct passwd * passwd = getpwuid(uid);
+        // Default mac address in case of failure
+        unsigned char mac_address[6] = {0x01, 0x02, 0x03, 0x04, 0x05};
+
+        get_mac_address(mac_address);
+
+        int dataToHashLen = 10 /* UID */ + strlen(passwd->pw_name) + sizeof(mac_address)*2 /*mac address*/ + 1 /* \0 */;
+        dataToHashLen += 8; /* Separators */
+        unsigned char* dataToHash = new unsigned char[dataToHashLen];
+        dataToHashLen = snprintf((char*)dataToHash, dataToHashLen, "%d:%s:%02x:%02x:%02x:%02x:%02x:%02x:",
+                                 uid, passwd->pw_name,
+                                 mac_address[0], mac_address[1], mac_address[2],
+                                 mac_address[3], mac_address[4], mac_address[5]);
+
+        client->digest("SHA1", dataToHash, dataToHashLen+1, sha_out);
+
+        delete[] dataToHash;
+      }
+    else
+      {
+        client->randBytes(sha_out, sizeof(sha_out));
+      }
+
+    std::string res = ByteArray((const char*)sha_out, DEVICE_SERIAL_LEN).toHex();
+    GOUROU_LOG(DEBUG, "Serial : " << res);
+    return res;
+  }
+
+  /* base64(SHA1 (serial + privateKey)) */
+  std::string Device::makeFingerprint(const std::string& serial)
+  {
+    DRMProcessorClient* client = processor->getClient();
+    unsigned char sha_out[SHA1_LEN];
+
+    void* handler = client->createDigest("SHA1");
+    client->digestUpdate(handler, (unsigned char*) serial.c_str(), serial.length());
+    client->digestUpdate(handler, deviceKey, sizeof(deviceKey));
+    client->digestFinalize(handler, sha_out);
+
+    std::string res = ByteArray(sha_out, sizeof(sha_out)).toBase64();
+    GOUROU_LOG(DEBUG, "Fingerprint : " << res);
+    return res;
+  }
+
+  void Device::createDeviceFile(const std::string& hobbes, bool randomSerial)
+  {
+    struct utsname sysname;
+    uname(&sysname);
+
+    std::string serial = makeSerial(randomSerial);
+    std::string fingerprint = makeFingerprint(serial);
+
+    pugi::xml_document deviceDoc;
+    pugi::xml_node decl = deviceDoc.append_child(pugi::node_declaration);
+    decl.append_attribute("version") = "1.0";
+
+    pugi::xml_node root = deviceDoc.append_child("adept:deviceInfo");
+    root.append_attribute("xmlns:adept") = ADOBE_ADEPT_NS;
+
+    appendTextElem(root, "adept:deviceClass",  "Desktop");
+    appendTextElem(root, "adept:deviceSerial", serial);
+    appendTextElem(root, "adept:deviceName",   sysname.nodename);
+    appendTextElem(root, "adept:deviceType",   "standalone");
+
+    pugi::xml_node version = root.append_child("adept:version");
+    version.append_attribute("name") = "hobbes";
+    version.append_attribute("value") = hobbes.c_str();
+
+    version = root.append_child("adept:version");
+    version.append_attribute("name") = "clientOS";
+    std::string os = std::string(sysname.sysname) + " " + std::string(sysname.release);
+    version.append_attribute("value") = os.c_str();
+
+    version = root.append_child("adept:version");
+    version.append_attribute("name") = "clientLocale";
+    version.append_attribute("value") = setlocale(LC_ALL, NULL);
+
+    appendTextElem(root, "adept:fingerprint", fingerprint);
+
+    StringXMLWriter xmlWriter;
+    deviceDoc.save(xmlWriter, "  ");
+
+    GOUROU_LOG(DEBUG, "Create device file " << deviceFile);
+
+    writeFile(deviceFile, xmlWriter.getResult());
+  }
+
+  void Device::createDeviceKeyFile()
+  {
+    unsigned char key[DEVICE_KEY_SIZE];
+
+    GOUROU_LOG(DEBUG, "Create device key file " << deviceKeyFile);
+
+    processor->getClient()->randBytes(key, sizeof(key));
+
+    writeFile(deviceKeyFile, key, sizeof(key));
+  }
+
+  Device* Device::createDevice(DRMProcessor* processor, const std::string& dirName, const std::string& hobbes, bool randomSerial)
+  {
+    struct stat _stat;
+
+    if (stat(dirName.c_str(), &_stat) != 0)
+      {
+        if (mkdir_p(dirName.c_str(), S_IRWXU))
+          EXCEPTION(DEV_MKPATH, "Unable to create " << dirName)
+            }
+
+    Device* device = new Device(processor);
+
+    device->deviceFile = dirName + "/device.xml";
+    device->deviceKeyFile = dirName + "/devicesalt";
+
+    try
+      {
+        device->parseDeviceKeyFile();
+      }
+    catch (...)
+      {
+        device->createDeviceKeyFile();
+        device->parseDeviceKeyFile();
+      }
+
+    try
+      {
+        device->parseDeviceFile();
+      }
+    catch (...)
+      {
+        device->createDeviceFile(hobbes, randomSerial);
+        device->parseDeviceFile();
+      }
+
+    return device;
+  }
+
+  const unsigned char* Device::getDeviceKey()
+  {
+    return deviceKey;
+  }
+
+  void Device::parseDeviceFile()
+  {
+    pugi::xml_document doc;
+
+    if (!doc.load_file(deviceFile.c_str()))
+      EXCEPTION(DEV_INVALID_DEVICE_FILE, "Invalid device file");
+
+    try
+      {
+        properties["deviceClass"]  = gourou::extractTextElem(doc, "/adept:deviceInfo/adept:deviceClass");
+        properties["deviceSerial"] = gourou::extractTextElem(doc, "/adept:deviceInfo/adept:deviceSerial");
+        properties["deviceName"]   = gourou::extractTextElem(doc, "/adept:deviceInfo/adept:deviceName");
+        properties["deviceType"]   = gourou::extractTextElem(doc, "/adept:deviceInfo/adept:deviceType");
+        properties["fingerprint"]  = gourou::extractTextElem(doc, "/adept:deviceInfo/adept:fingerprint");
+
+        pugi::xpath_node_set nodeSet = doc.select_nodes("/adept:deviceInfo/adept:version");
+
+        for (pugi::xpath_node_set::const_iterator it = nodeSet.begin();
+             it != nodeSet.end(); ++it)
+          {
+            pugi::xml_node node = it->node();
+            pugi::xml_attribute name = node.attribute("name");
+            pugi::xml_attribute value = node.attribute("value");
+
+            properties[name.value()] = value.value();
+          }
+      }
+    catch (gourou::Exception& e)
+      {
+        EXCEPTION(DEV_INVALID_DEVICE_FILE, "Invalid device file");
+      }
+  }
+
+  void Device::parseDeviceKeyFile()
+  {
+    struct stat _stat;
+
+    if (stat(deviceKeyFile.c_str(), &_stat) == 0 &&
+        _stat.st_size == DEVICE_KEY_SIZE)
+      {
+        readFile(deviceKeyFile, deviceKey, sizeof(deviceKey));
+      }
+    else
+      EXCEPTION(DEV_INVALID_DEVICE_KEY_FILE, "Invalid device key file");
+  }
+
+  std::string Device::getProperty(const std::string& property, const std::string& _default)
+  {
+    if (properties.find(property) == properties.end())
+      {
+        if (_default == "")
+          EXCEPTION(DEV_INVALID_DEV_PROPERTY, "Invalid property " << property);
+
+        return _default;
+      }
+
+    return properties[property];
+  }
+
+  std::string Device::operator[](const std::string& property)
+  {
+    return getProperty(property);
+  }
+}


### PR DESCRIPTION
Multi-System support (linux & mac for now).

I needed to change out the `get_mac_address` in `gourou/src/device.cpp`. With a little bit more time one could make it platform-independent and open a PR on `gourou` (it should work cross-platform but I didn't guard the includes yet).

I couldn't test it on non-`aarch64` linux yet. I tested it with `arm64-darwin`, `x86_64-darwin` & `aarch64-linux`.

`pkgsStatic` doesn't work on `darwin` as expected and still builds the dependencies dynamically.
This means that we'd need to bundle everything together to provide a downloadable release. Some of them should be on the system by default, but at least on my system it doesn't find libs like `libunistring` when I remove it from nix-store.
The libraries in question are:
```
➤  otool -L result/bin/knock
result/bin/knock:
	/nix/store/<...>/lib/libnghttp2.14.dylib (compatibility version 36.0.0, current version 36.2.0)
	/nix/store/<...>/lib/libidn2.0.dylib (compatibility version 4.0.0, current version 4.7.0)
	/nix/store/<...>/lib/libunistring.2.dylib (compatibility version 5.0.0, current version 5.0.0)
	/nix/store/<...>/lib/libssh2.1.dylib (compatibility version 2.0.0, current version 2.1.0)
	/nix/store/<...>/lib/libzstd.1.5.2.dylib (compatibility version 1.0.0, current version 1.5.2)
	/nix/store/<...>/lib/libz.dylib (compatibility version 1.0.0, current version 1.2.12)
	/nix/store/<...>/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/nix/store/<...>/lib/libcurl.4.dylib (compatibility version 13.0.0, current version 13.0.0)
	/nix/store/<...>/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/nix/store/<...>/lib/libc++.1.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.60.1)
```

_(Also this was my first ever touchpoint with anything `nix` and I may have fallen down a rabbit-hole here, so thanks for that I guess 😃)_