### PR TITLE
Add Dockerfile to build Knock with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Build Knock from repo with Docker to avoid dependency hell on your host
+# machine. The multistage build produces a slim scratch-based container with
+# only the Knock binary.
+#
+# Building:
+# docker build -t knock .
+#
+# Usage example for satellite-dish-trouble.acsm in current directory:
+# docker run -v "$PWD":/tmp knock /tmp/satellite-dish-trouble.acsm
+
+ARG NIX_VERSION=2.11.1
+ARG BUILD_DIR=/usr/local/build/nix
+
+FROM nixos/nix:$NIX_VERSION AS builder
+ARG BUILD_DIR
+WORKDIR /etc/nix
+RUN echo 'experimental-features = nix-command flakes' >> nix.conf
+WORKDIR "$BUILD_DIR"
+COPY . ./
+RUN nix build
+
+FROM scratch
+ARG BUILD_DIR
+COPY --from=builder "$BUILD_DIR"/result/bin/knock /
+ENTRYPOINT ["/knock"]


### PR DESCRIPTION
It is convenient to use a containerized build environment to avoid the hassle with dependencies on the build machine. Furthermore, it provides a consistent build setup for all users. And last but not least, having Knock available as a (multi-arch) container in a container registry makes it easy to run and eliminates the need for the user to run `uname -ms` and perform manual download.

Signed-off-by: Joakim Roubert <joakim.roubert@gmail.com>